### PR TITLE
Add GumGum adapter notification opt-in

### DIFF
--- a/.github/adapter_change_notifications.yml
+++ b/.github/adapter_change_notifications.yml
@@ -1,0 +1,5 @@
+# Mapping of adapters to email addresses for change notifications
+# Add your adapter name and email to receive notifications about code updates
+notifications:
+  gumgum:
+    - prebid@gumgum.com

--- a/static/bidder-info/gumgum.yaml
+++ b/static/bidder-info/gumgum.yaml
@@ -1,6 +1,7 @@
 endpoint: "https://g2.gumgum.com/providers/prbds2s/bid"
 maintainer:
   email: "prebid@gumgum.com"
+  change_notification_email: "prebid@gumgum.com"
 gvlVendorID: 61
 capabilities:
   site:


### PR DESCRIPTION
## Summary
- add new `.github/adapter_change_notifications.yml` to list adapter emails for update notices
- opt in GumGum adapter

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.20.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_684899a60970832687119a88eb0f53b5